### PR TITLE
Harden ENVI naming and config discovery with logging

### DIFF
--- a/bin/jefe.py
+++ b/bin/jefe.py
@@ -90,6 +90,11 @@ def go_forth_and_multiply(base_folder="output", resample_method: str = 'convolut
     # Step 2: Convert flight lines to ENVI format
     flight_lines_to_envi(input_dir=base_folder, output_dir=base_folder)
 
+    print("\U0001F4C1 Listing generated ENVI files:")
+    base_path = Path(base_folder)
+    for file in sorted(base_path.rglob("*envi.hdr")):
+        print("  \U0001F4C4", file)
+
     # Step 3: Generate configuration JSON
     generate_config_json(base_folder)
 

--- a/docs/debugging_envi_naming.md
+++ b/docs/debugging_envi_naming.md
@@ -1,0 +1,41 @@
+# Debugging ENVI Naming Issues
+
+This document provides guidance for troubleshooting the NEON hyperspectral
+pipeline when files fail to move through the BRDF correction and resampling
+steps.
+
+## Pipeline overview
+
+1. `download_neon_flight_lines` retrieves raw NEON HDF5 flight lines.
+2. `flight_lines_to_envi` converts each HDF5 file to ENVI format.
+3. `generate_config_json` scans for `_reflectance_envi` products and writes
+   configuration JSON files.
+4. `topo_and_brdf_correction` uses those configs to create corrected imagery.
+5. Resampling functions translate the corrected imagery into other sensor
+   formats.
+
+## Typical failure points
+
+- Missing or unexpected filename suffixes prevent `generate_config_json` from
+  locating ENVI outputs.
+- If no config files are written, BRDF correction and resampling steps
+  silently skip.
+
+## Suffix handling
+
+The pipeline expects ENVI outputs with `_reflectance_envi` in their names.
+Alternate HDF5 inputs may omit this suffix in their metadata, producing files
+that do not match the strict pattern and are ignored downstream.
+
+## Debugging tips
+
+- After ENVI conversion the pipeline lists every `*envi.hdr` file it created.
+  Verify that the expected suffix appears.
+- `generate_config_json` reports the paths of each config it writes and warns if
+  none were generated.
+- `NEONReflectanceConfigFile.find_in_directory` can run with `verbose=True` to
+  show which files were ignored and why.
+
+Use these logs and simple file listings to ensure that filenames match the
+patterns expected by downstream steps.
+

--- a/src/file_types.py
+++ b/src/file_types.py
@@ -418,10 +418,27 @@ class NEONReflectanceConfigFile(DataFile):
 
     @classmethod
     def find_in_directory(
-        cls, directory: Path, suffix: Optional[str] = None
+        cls, directory: Path, suffix: Optional[str] = None, verbose: bool = False
     ) -> List["NEONReflectanceConfigFile"]:
         files = super().find_in_directory(directory)
-        return [f for f in files if suffix is None or f.suffix == suffix]
+        matched: List["NEONReflectanceConfigFile"] = []
+        for f in files:
+            if suffix is None or f.suffix == suffix:
+                matched.append(f)
+            elif verbose:
+                print(
+                    f"Ignoring config file {f.path} due to suffix '{f.suffix}' != '{suffix}'"
+                )
+        if verbose:
+            if matched:
+                print(
+                    f"Found {len(matched)} config file(s) in {directory} with suffix='{suffix}'"
+                )
+            else:
+                print(
+                    f"No config files found in {directory} with suffix='{suffix}'"
+                )
+        return matched
 
 
 class NEONReflectanceBRDFCorrectedENVIFile(MaskedFileMixin, DataFile):

--- a/src/neon_to_envi.py
+++ b/src/neon_to_envi.py
@@ -51,7 +51,7 @@ def neon_to_envi_task(hy_obj, output_dir, metadata=None):
             date=metadata.get("date", "00000000"),
             time=metadata.get("time", "000000"),
             tile=metadata.get("tile", "L000-0"),
-            suffix=metadata.get("suffix", None)
+            suffix=metadata.get("suffix") or "directional_reflectance"
         )
     else:
         try:


### PR DESCRIPTION
## Summary
- default ENVI metadata overrides to `directional_reflectance`
- log generated ENVI outputs after conversion
- improve config discovery with verbose logging and result counts
- document debugging workflow for ENVI naming issues

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689f953846d48325923436bec9380671