### PR TITLE
Add docs build and GH Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: gh-pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -1,0 +1,18 @@
+# Developer Notes
+
+Use the following commands to work on the documentation locally:
+
+1. Install dependencies:
+   ```bash
+   pip install -r docs/requirements.txt
+   # or
+   uv pip install -r docs/requirements.txt
+   ```
+2. Start a live preview:
+   ```bash
+   mkdocs serve
+   ```
+3. Build the static site:
+   ```bash
+   mkdocs build
+   ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material
+mkdocstrings


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow to build and deploy MkDocs site
- document local commands for building docs
- list required MkDocs dependencies

## Testing
- ⚠️ `pip install pandas` (failed: Could not connect to proxy)
- ⚠️ `pytest` (missing module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68a3a2e5ca608325b84113feee746a50