### PR TITLE
Fix documentation build warnings

### DIFF
--- a/docs/stage-02-sorting.md
+++ b/docs/stage-02-sorting.md
@@ -38,9 +38,9 @@ rerunning the command recreates the same layout without duplicating files.
    reruns skip unchanged files and resume incomplete transfers.
 
 ## Reference
-- [`src/file_sort.py`](../src/file_sort.py) implements sorting and iRODS path rules
-- [`bin/jefe.py`](../bin/jefe.py) provides the `sort_and_sync_files` entry point
-- [CyVerse iRODS](cyverse-irods.md) covers authentication and environment setup
+ - [`src/file_sort.py`](https://github.com/earthlab/cross-sensor-cal/blob/main/src/file_sort.py) implements sorting and iRODS path rules
+ - [`bin/jefe.py`](https://github.com/earthlab/cross-sensor-cal/blob/main/bin/jefe.py) provides the `sort_and_sync_files` entry point
+ - [CyVerse iRODS](cyverse-irods.md) covers authentication and environment setup
 
 ## Next steps
 Proceed to [Stage 03 Pixel Extraction](stage-03-pixel-extraction.md) once files

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -65,8 +65,4 @@ assert (abund.filter(like="EM").sum(axis=1) <= 1.01).all()
 assert (abund.filter(like="EM") >= 0).all().all()
 ```
 
-### Example Screenshots
-| Pass | Fail |
-|------|------|
-| ![pass example](img/validation_pass.png) | ![fail example](img/validation_fail.png) |
 <!-- FILLME:END -->


### PR DESCRIPTION
## Summary
- Replace internal references to source scripts with links to the repository on GitHub
- Remove broken validation screenshot links so MkDocs can build in strict mode

## Testing
- `mkdocs build --strict`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a3a55017908325ac831a29189c2c8b