### PR TITLE
Move spectral parquet output directory up one level

### DIFF
--- a/docs/stage-03-pixel-extraction.md
+++ b/docs/stage-03-pixel-extraction.md
@@ -25,6 +25,7 @@ Choose the approach that matches your hardware and scene size; the output format
 Each row represents one pixel.
 Columns typically include `scene_id`, `tile_id`, `x`, `y`, band values, and `is_masked`.
 Write tables as CSV for quick inspection or Parquet for efficient storage.
+Keep Parquet outputs in a `full_extracted_pixels` folder that lives alongside the tile folder so the extracted tables sit next to, not inside, the source data.
 Partition by scene and tile so you can read subsets without loading the whole dataset.
 
 ## Memory tips

--- a/src/file_types.py
+++ b/src/file_types.py
@@ -1094,7 +1094,7 @@ class SpectralDataParquetFile(DataFile):
     def from_raster_file(cls, raster_file: DataFile) -> "SpectralDataParquetFile":
         base = raster_file.path.stem
         filename = f"{base}_spectral_data.parquet"
-        output_directory = raster_file.path.parent / "full_extracted_pixels"
+        output_directory = raster_file.path.parent.parent / "full_extracted_pixels"
         output_directory.mkdir(parents=True, exist_ok=True)
         return cls(output_directory / filename, base=base)
 

--- a/tests/test_file_sort.py
+++ b/tests/test_file_sort.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.file_sort import categorize_file, generate_file_move_list
 from src.file_types import (
+    DataFile,
     NEONReflectanceFile,
     NEONReflectanceENVIFile,
     NEONReflectanceENVHDRFile,
@@ -30,6 +31,32 @@ from src.file_types import (
     SpectralDataParquetFile,
     SensorType,
 )
+
+
+class TestSpectralDataParquetFile(unittest.TestCase):
+    """Tests for the SpectralDataParquetFile helper."""
+
+    def test_from_raster_file_uses_parent_directory(self):
+        """Ensure Parquet outputs are placed alongside the raster folder."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            parent_dir = Path(tmpdir) / "processed_scene"
+            raster_dir = parent_dir / "tile_001"
+            raster_dir.mkdir(parents=True)
+
+            raster_path = raster_dir / "NEON_D13_NIWO_DP1_20200801_161441_reflectance.h5"
+            raster_path.touch()
+
+            raster_file = DataFile(raster_path)
+            parquet_file = SpectralDataParquetFile.from_raster_file(raster_file)
+
+            expected_directory = parent_dir / "full_extracted_pixels"
+
+            self.assertTrue(expected_directory.is_dir())
+            self.assertEqual(parquet_file.path.parent, expected_directory)
+            self.assertEqual(
+                parquet_file.path.name,
+                "NEON_D13_NIWO_DP1_20200801_161441_reflectance_spectral_data.parquet",
+            )
 
 
 class TestCategorizeFile(unittest.TestCase):


### PR DESCRIPTION
## Summary
- update the spectral Parquet helper to place `full_extracted_pixels` beside the raster folder rather than inside it
- document the new Parquet output location in the Stage 03 pixel extraction guide
- add a regression test ensuring the helper creates the folder in the expected location

## Testing
- `pytest tests/test_file_sort.py` *(fails: missing pandas dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e81d9b88832595a7da1a13bda546