### PR TITLE
test: expand path helper assertions and log prompt

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -233,3 +233,10 @@ tests/test_duckdb_merge.py:114:
 [...]
 Error: Process completed with exit code 1.
 ```
+
+## 2026-03-22 - small test update for PR creation check
+Branch: work
+
+```text
+can you make a small test update to check that you can create PRs?
+```

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -27,9 +27,13 @@ def test_flightline_paths_properties(tmp_path: Path):
     assert paths.flight_dir == base / flight_id
     assert paths.h5 == base / f"{flight_id}.h5"
     assert paths.envi_img == base / flight_id / f"{flight_id}_envi.img"
-    assert paths.corrected_json.name.endswith("_brdfandtopo_corrected_envi.json")
+    assert paths.corrected_json == base / flight_id / f"{flight_id}_brdfandtopo_corrected_envi.json"
+    assert paths.merged_parquet == base / flight_id / f"{flight_id}_merged_pixel_extraction.parquet"
 
     sensor = paths.sensor_product("landsat_oli")
-    assert sensor.img.name.endswith("landsat_oli_envi.img")
-    assert sensor.parquet.name.endswith("landsat_oli_envi.parquet")
-    assert sensor.qa_png.name.endswith("landsat_oli_envi_qa.png")
+    assert sensor.img == base / flight_id / f"{flight_id}_landsat_oli_envi.img"
+    assert sensor.hdr == base / flight_id / f"{flight_id}_landsat_oli_envi.hdr"
+    assert sensor.parquet == base / flight_id / f"{flight_id}_landsat_oli_envi.parquet"
+    assert sensor.qa_png == base / flight_id / f"{flight_id}_landsat_oli_envi_qa.png"
+    assert sensor.qa_pdf == base / flight_id / f"{flight_id}_landsat_oli_envi_qa.pdf"
+    assert sensor.qa_json == base / flight_id / f"{flight_id}_landsat_oli_envi_qa.json"


### PR DESCRIPTION
### Motivation
- Add a minimal test-only change to verify PR creation and to assert canonical path helper outputs while also appending the user prompt to `PROMPT_LOG.md` to satisfy the repository prompt-logging requirement.

### Description
- Expanded assertions in `tests/test_paths.py` to validate exact canonical outputs for `FlightlinePaths` (checking `corrected_json` and `merged_parquet`) and for `SensorProductPaths` for `landsat_oli` (checking `img`, `hdr`, `parquet`, `qa_png`, `qa_pdf`, and `qa_json`), and appended the verbatim prompt to `PROMPT_LOG.md`.

### Testing
- Ran `pytest -q tests/test_paths.py` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff3729fcc832587beb6acd58b73a0)